### PR TITLE
Fix planet info header

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    commit-message:
+      # Avoid netlify preview builds for dependabot PRs
+      prefix: "[skip netlify]"

--- a/app/src/features/PlanetDecoder.tsx
+++ b/app/src/features/PlanetDecoder.tsx
@@ -50,7 +50,7 @@ export const PlanetDecoder: React.FC = () => {
       </div>
       {planetInfo && (
           <>
-            <Heading align="right"><span data-test-id="name">{planetInfo.name}</span></Heading>
+            <Heading align="right" data-test-id="name">{planetInfo.name}</Heading>
             <List>
               <ListItem color="pale-orange">Size: <span className='pale-orange' data-test-id="size">{planetInfo.size}</span></ListItem>
               <ListItem color="starlight">Atmosphere: <span className='starlight' data-test-id="atmosphere">{planetInfo.atmosphere}</span></ListItem>

--- a/app/src/lcars/Heading.tsx
+++ b/app/src/lcars/Heading.tsx
@@ -1,12 +1,12 @@
-import { type FC, type PropsWithChildren } from 'react'
+import type { FC, HTMLAttributes, PropsWithChildren } from 'react'
 import classNames from 'classnames'
 
-export interface HeadingProps {
+export interface HeadingProps extends HTMLAttributes<HTMLSpanElement> {
   align: 'left' | 'right'
 }
 
-export const Heading: FC<PropsWithChildren<HeadingProps>> = ({ align, children }) => {
+export const Heading: FC<PropsWithChildren<HeadingProps>> = ({ align, children, ...props }) => {
   return (
-    <div role="heading" className={classNames('lcars-text-bar', { 'the-end': align === 'right' })}><span>{children}</span></div>
+    <div role="heading" className={classNames('lcars-text-bar', { 'the-end': align === 'right' })}><span {...props}>{children}</span></div>
   )
 }


### PR DESCRIPTION
The planet info header in the planet decoder was wrapping the text because of the extra span inside it.
I made the Header component to proxy all the extra attributes into the underlaying span and removed the extra span I added just for testing purposes

@netlify /