### PR TITLE
Group patches and minor upgrades in one single MR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,17 @@ updates:
     commit-message:
       # Avoid netlify preview builds for dependabot PRs
       prefix: "[skip netlify]"
+    open-pull-requests-limit: 10
+    versioning-strategy: auto
+    groups:
+      patches:
+        patterns:
+          - "*"
+        update-types:
+          - patch
+      minors:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+


### PR DESCRIPTION
Modify dependabot to create one single MR for all patch upgrades and one single MR for all minor upgrades.